### PR TITLE
feat(engine): Pops may now migrate.

### DIFF
--- a/src/data/names.ts
+++ b/src/data/names.ts
@@ -44,7 +44,7 @@ export const SYSTEM_NAMES: string[] = [
 "Oolitic", "Ohia", "Osisi", "Onn", "Okir", "Orghret",
 "Ping", "Pi Li", "Punarpusam", "Puram", "Puratam", "Pomp Aer", "Pempont", "Pholiota", "Pallavaram", "Pernambut", "Padaiveeran", "Pezh", "Pirtuni",
 "Qafzah", "Qaws", "Qayd", "Qurhah", "Qanturus", "Qalab", "Qi Guan", "Qaqim", "Quadinar",
-"Risha", "Rijl", "Rogini", "Ravajul", "Russula", "Ruis",
+"Risha", "Rijl", "Rogini", "Ravajul", "Russula", "Ruis", "Rawdah",
 "Sabiq", "Sayf", "Saq", "Shawlah", "Sharatan", "Surrat", "Samak", "Shang Wei", "Shang Cheng", "Shi Lou", "Si Fei", "Suvati", "Sadayam", "Satavis", "Shajarah", "Shu", "Saezhataer", "Shram", "Saffaras", "Summaq", "Saille", "Straif", "Shapash", "Silur",
 "Ta'ir", "Tays", "Thu'ban", "Tarf", "Turafah", "Tuwayba'", "Tiruvadirai", "Thuraya", "Tian Quan", "Tu Si", "Teng She", "Tanuwin", "Tinne", "Tittakudi",
 "Uttiram", "Uhelgoad", "Uath", "Uir", "Uilleann",

--- a/src/engine/politics/politics.ts
+++ b/src/engine/politics/politics.ts
@@ -1,10 +1,12 @@
 import type { GameState, EngineResult, GameEvent } from '../../types/gameState';
-import { averagePopHappiness } from '../population';
+import { averagePopHappiness, findMigrationTarget, migratePop } from '../population';
 import { determinePotentialIdeology, spawnMovement } from './movements';
 
 export function processPolitics(currentState: GameState ): EngineResult {
     const planetoids = Object.values(currentState.planetoids.entities);
     const allPoliticsEvents: GameEvent[] = [];
+
+     let nextState = { ...currentState };
 
     let movementTargets: number[] = [];
 
@@ -22,10 +24,19 @@ export function processPolitics(currentState: GameState ): EngineResult {
                     movementTargets.push(planetoid.id);
                 }
             }
+
+            for(const pop of planetoidPops){
+                if(pop.feelings.happiness < 20){
+                    const migrationRoll = Math.random() * 100;
+                    if(migrationRoll > 98){
+                        nextState = migratePop(nextState, pop.id, findMigrationTarget(nextState, pop.id))
+                    }
+                }
+            }
         }
     }
 
-    let nextState = { ...currentState };
+
 
 
      for(const target of movementTargets){

--- a/src/engine/population.ts
+++ b/src/engine/population.ts
@@ -1,5 +1,6 @@
 import { CYCLE_CONFIG } from '../constants/cycle_config';
 import type { GameState, Pop } from '../types/gameState';
+import { evaluatePlanetoidValue, getHabitablesInSystem } from './colonization';
 
 
 export function popIncreaseSpeciesRoll(currentState: GameState, planetoidId: number): number | null {
@@ -79,6 +80,36 @@ export function gatherCitizenPops(currentState: GameState, orgId: number): Pop[]
     }
 
     return citizenPops;
+}
+
+export function findMigrationTarget(currentState: GameState, popId: number): number {
+    const pop = currentState.pops.entities[popId];
+
+    let currentOption = pop.locationId;
+    let topValue = 0;
+
+    const popSystem = currentState.systems.entities[currentState.planetoids.entities[pop.locationId].locationSystemId];
+
+    //poss TODO: allow looking at neighbors of neighbors?
+
+    for(const sysId of popSystem.adjacentSystemIds){
+        const sysHabitables = getHabitablesInSystem(currentState, sysId);
+        for(const habitable of sysHabitables){
+            let habValue = evaluatePlanetoidValue(habitable);
+
+            if(habitable.population){
+                const planetoidPops = habitable.population.popIds.map(popId => currentState.pops.entities[popId]);
+                habValue += (averagePopHappiness(planetoidPops) - 50) / 10;
+            }
+
+            if(habValue > topValue){
+                currentOption = habitable.id;
+                topValue = habValue;
+            }
+        }
+    }
+
+    return currentOption;
 }
 
 export function migratePop(currentState: GameState, popId: number, destinationId: number): GameState {

--- a/src/engine/population.ts
+++ b/src/engine/population.ts
@@ -80,3 +80,73 @@ export function gatherCitizenPops(currentState: GameState, orgId: number): Pop[]
 
     return citizenPops;
 }
+
+export function migratePop(currentState: GameState, popId: number, destinationId: number): GameState {
+    let pop = { ... currentState.pops.entities[popId]};
+    const originId = pop.locationId;
+
+
+    let originPlanetoid = { ...currentState.planetoids.entities[originId]};
+    let destinationPlanetoid = { ...currentState.planetoids.entities[destinationId]};
+
+    if(!originPlanetoid.population){
+        return currentState;
+    }
+
+    pop = {
+        ...pop,
+        locationId: destinationId
+    };
+
+    let originPops = originPlanetoid.population.popIds.filter(cPopId => cPopId !== popId);
+
+    originPlanetoid = {
+        ...originPlanetoid,
+        population: {
+            ...originPlanetoid.population,
+            popIds: originPops,
+            total: originPlanetoid.population.total - 1
+        }
+    };
+
+    if(destinationPlanetoid.population){
+        destinationPlanetoid = {
+            ...destinationPlanetoid,
+            population: {
+                ...destinationPlanetoid.population,
+                popIds: [ ...destinationPlanetoid.population.popIds, popId],
+                total: destinationPlanetoid.population.total + 1
+            }
+        };
+    }
+    else{
+        destinationPlanetoid =  {
+            ...destinationPlanetoid,
+            population: {
+                popIds: [popId],
+                total: 1,
+                progress: 0
+            }
+        };
+    }
+
+    return {
+        ...currentState,
+        pops: {
+            ...currentState.pops,
+            entities: {
+                ...currentState.pops.entities,
+                [popId]: pop
+            }
+        },
+        planetoids: {
+            ...currentState.planetoids,
+            entities: {
+                ...currentState.planetoids.entities,
+                [originId]: originPlanetoid,
+                [destinationId]: destinationPlanetoid
+            }
+        }
+    }
+
+}

--- a/src/engine/population.ts
+++ b/src/engine/population.ts
@@ -127,6 +127,10 @@ export function migratePop(currentState: GameState, popId: number, destinationId
     pop = {
         ...pop,
         locationId: destinationId
+        feelings: {
+            ...pop.feelings,
+            happiness: 70 //reset so that the pop doesn't want to immediately migrate again
+        }
     };
 
     let originPops = originPlanetoid.population.popIds.filter(cPopId => cPopId !== popId);

--- a/src/engine/population.ts
+++ b/src/engine/population.ts
@@ -126,7 +126,7 @@ export function migratePop(currentState: GameState, popId: number, destinationId
 
     pop = {
         ...pop,
-        locationId: destinationId
+        locationId: destinationId,
         feelings: {
             ...pop.feelings,
             happiness: 70 //reset so that the pop doesn't want to immediately migrate again


### PR DESCRIPTION
Added Pop migration for low happiness Pops. This includes migration to uncolonized Planetoids. Closes #102. Closes #103 