### PR TITLE
feat(engine): enabled Cell functionality

### DIFF
--- a/src/data/cellActivities.ts
+++ b/src/data/cellActivities.ts
@@ -12,6 +12,8 @@ export const CASSIGNMENT_CATALOG: Record<string, CellAssignmentDefinition> = {
     "idle": {
         assignmentId: "idle",
         duration: 1000,
+        //target is irrelevant but typically Cell's ID
+
 
         onComplete: (currentState, targetId) => {
             if(targetId){
@@ -24,6 +26,7 @@ export const CASSIGNMENT_CATALOG: Record<string, CellAssignmentDefinition> = {
     "assassinateGovernor": {
         assignmentId: "assassinateGovernor",
         duration: 5,
+        //target is the Planetoid ID
 
        onComplete: (currentState, targetId) => {
             const governorId = currentState.systems.entities[currentState.planetoids.entities[targetId].locationSystemId].assignedCharacter;
@@ -36,6 +39,7 @@ export const CASSIGNMENT_CATALOG: Record<string, CellAssignmentDefinition> = {
     "gatherStrength": {
         assignmentId: "gatherStrength",
         duration: 5,
+        //target is the Cell's ID'
 
         onComplete: (currentState, targetId) => {
             return {

--- a/src/data/cellActivities.ts
+++ b/src/data/cellActivities.ts
@@ -1,0 +1,10 @@
+import type { GameState } from '../types/gameState';
+
+
+export interface CellAssignmentDefinition {
+    assignmentId: string;
+    duration: number;
+
+    allowedCellTypes: string[];
+    onComplete?: (currentState: GameState, targetId: number) => GameState;
+}

--- a/src/data/cellActivities.ts
+++ b/src/data/cellActivities.ts
@@ -9,6 +9,18 @@ export interface CellAssignmentDefinition {
 }
 
 export const CASSIGNMENT_CATALOG: Record<string, CellAssignmentDefinition> = {
+    "idle": {
+        assignmentId: "idle",
+        duration: 1000,
+
+        onComplete: (currentState, targetId) => {
+            if(targetId){
+                return currentState;
+            }
+            return currentState;
+        }
+    },
+
     "assassinateGovernor": {
         assignmentId: "assassinateGovernor",
         duration: 5,

--- a/src/data/cellActivities.ts
+++ b/src/data/cellActivities.ts
@@ -5,7 +5,7 @@ export interface CellAssignmentDefinition {
     assignmentId: string;
     duration: number;
 
-    onComplete: (currentState: GameState, targetId: number) => GameState;
+    onComplete: (currentState: GameState,  targetId: number) => GameState;
 }
 
 export const CASSIGNMENT_CATALOG: Record<string, CellAssignmentDefinition> = {
@@ -20,5 +20,25 @@ export const CASSIGNMENT_CATALOG: Record<string, CellAssignmentDefinition> = {
             }
             return killCharacter(currentState, governorId);
        }
+    },
+    "gatherStrength": {
+        assignmentId: "gatherStrength",
+        duration: 5,
+
+        onComplete: (currentState, targetId) => {
+            return {
+                ...currentState,
+                cells: {
+                    ...currentState.cells,
+                    entities: {
+                        ...currentState.cells.entities,
+                        [targetId]: {
+                            ...currentState.cells.entities[targetId],
+                            strength: currentState.cells.entities[targetId].strength + 1
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/data/cellActivities.ts
+++ b/src/data/cellActivities.ts
@@ -1,10 +1,24 @@
 import type { GameState } from '../types/gameState';
-
+import { killCharacter } from '../engine/character';
 
 export interface CellAssignmentDefinition {
     assignmentId: string;
     duration: number;
 
-    allowedCellTypes: string[];
-    onComplete?: (currentState: GameState, targetId: number) => GameState;
+    onComplete: (currentState: GameState, targetId: number) => GameState;
+}
+
+export const CASSIGNMENT_CATALOG: Record<string, CellAssignmentDefinition> = {
+    "assassinateGovernor": {
+        assignmentId: "assassinateGovernor",
+        duration: 5,
+
+       onComplete: (currentState, targetId) => {
+            const governorId = currentState.systems.entities[currentState.planetoids.entities[targetId].locationSystemId].assignedCharacter;
+            if(governorId === null){
+                return currentState;
+            }
+            return killCharacter(currentState, governorId);
+       }
+    }
 }

--- a/src/data/cellActivities.ts
+++ b/src/data/cellActivities.ts
@@ -14,7 +14,6 @@ export const CASSIGNMENT_CATALOG: Record<string, CellAssignmentDefinition> = {
         duration: 1000,
         //target is irrelevant but typically Cell's ID
 
-
         onComplete: (currentState, targetId) => {
             if(targetId){
                 return currentState;

--- a/src/data/research.ts
+++ b/src/data/research.ts
@@ -73,7 +73,7 @@ export const RESEARCH_CATALOG: Record<string, ResearchDefinition> = {
                                 ...currentState.orgs.entities[orgId].research,
                                 researchBonuses: {
                                     ...currentState.orgs.entities[orgId].research.researchBonuses,
-                                    depositSurvey: currentState.orgs.entities[orgId].research.researchBonuses.fleetCombat + 5,
+                                    fleetCombat: currentState.orgs.entities[orgId].research.researchBonuses.fleetCombat + 5,
                                 }
                             }
                         }

--- a/src/engine/politics/cells.ts
+++ b/src/engine/politics/cells.ts
@@ -1,6 +1,44 @@
 import type { GameState } from '../../types/gameState';
-import type { CellType, Cell } from '../../types/govState';
+import type { CellType, Cell, CellAssignmentType } from '../../types/govState';
 import { generateCharacter } from '../character';
+
+
+export function selectNewCellAssignment(currentState: GameState, cellId: number): GameState {
+    let cell = { ...currentState.cells.entities[cellId] };
+
+    if(cell.type === 'rebel'){
+       const possAssignments: CellAssignmentType[] = [ "assassinateGovernor", "gatherStrength"];
+        const assignmentRoll = Math.random() * possAssignments.length;
+
+        let assignmentTarget = cellId;
+
+        if(possAssignments[assignmentRoll] === 'assassinateGovernor'){
+            assignmentTarget = cell.locationId;
+        }
+
+        cell = {
+            ...cell,
+            assignment: {
+                ...cell.assignment,
+                type: possAssignments[assignmentRoll],
+                progress: 0,
+                target: assignmentTarget
+            }
+        };
+    }
+
+    return {
+        ...currentState,
+        cells: {
+            ...currentState.cells,
+            entities: {
+                ...currentState.cells.entities,
+                [cellId]: cell
+            }
+        }
+    }
+
+}
 
 export function spawnCellRandomLeader(currentState: GameState, planetoidId: number, cellType: CellType): GameState {
 

--- a/src/engine/politics/cells.ts
+++ b/src/engine/politics/cells.ts
@@ -49,6 +49,7 @@ export function spawnCell(currentState: GameState, planetoidId: number, cellType
         assignment: {
             type: 'idle',
             progress: 0,
+            target: nextId
         }
     }
 

--- a/src/engine/politics/politics.ts
+++ b/src/engine/politics/politics.ts
@@ -1,7 +1,7 @@
 import type { GameState, EngineResult, GameEvent } from '../../types/gameState';
 import { averagePopHappiness, findMigrationTarget, migratePop } from '../population';
 import { determinePotentialIdeology, spawnMovement } from './movements';
-import { spawnCellRandomLeader } from './cells';
+import { spawnCellRandomLeader, selectNewCellAssignment } from './cells';
 import { CASSIGNMENT_CATALOG } from '../../data/cellActivities';
 
 export function processPolitics(currentState: GameState ): EngineResult {
@@ -70,6 +70,7 @@ export function processPolitics(currentState: GameState ): EngineResult {
     for(const cell of cells){
         if(cell.assignment.type === 'idle'){
             //new assignment
+            nextState = selectNewCellAssignment(nextState, cell.id);
         }
         else if(cell.assignment.progress === CASSIGNMENT_CATALOG[cell.assignment.type].duration){
             //complete assignment

--- a/src/engine/politics/politics.ts
+++ b/src/engine/politics/politics.ts
@@ -73,14 +73,15 @@ export function processPolitics(currentState: GameState ): EngineResult {
         }
         else if(cell.assignment.progress === CASSIGNMENT_CATALOG[cell.assignment.type].duration){
             //complete assignment
+            nextState = CASSIGNMENT_CATALOG[cell.assignment.type].onComplete(nextState, cell.assignment.target);
         }
         else{
-            //progress assignment
+            //progress assignment - deferred to later
             incrementDuration = [ ...incrementDuration, cell.id];
         }
     }
 
-    //4 - increment durations
+    //evaluation of incrementDurations
     let newCells = { ...nextState.cells.entities };
     for(const cellId of incrementDuration){
         newCells[cellId] = {
@@ -92,6 +93,13 @@ export function processPolitics(currentState: GameState ): EngineResult {
         };
     }
 
+    nextState = {
+        ...nextState,
+        cells: {
+            ...nextState.cells,
+            entities: newCells
+        }
+    };
 
     return { newState: nextState, events: allPoliticsEvents };
 }

--- a/src/engine/politics/politics.ts
+++ b/src/engine/politics/politics.ts
@@ -1,6 +1,7 @@
 import type { GameState, EngineResult, GameEvent } from '../../types/gameState';
 import { averagePopHappiness, findMigrationTarget, migratePop } from '../population';
 import { determinePotentialIdeology, spawnMovement } from './movements';
+import { spawnCellRandomLeader } from './cells';
 
 export function processPolitics(currentState: GameState ): EngineResult {
     const planetoids = Object.values(currentState.planetoids.entities);
@@ -8,6 +9,8 @@ export function processPolitics(currentState: GameState ): EngineResult {
 
      let nextState = { ...currentState };
 
+
+     //1 - spawning new movements
     let movementTargets: number[] = [];
 
     for(const planetoid of planetoids){
@@ -36,8 +39,19 @@ export function processPolitics(currentState: GameState ): EngineResult {
         }
     }
 
+    //2 - spawning new Cells based on movements
+    const movements = Object.values(currentState.movements.entities);
 
+    for(const movement of movements){
+        if(movement.fervor < 7){
+            continue;
+        }
 
+        const cellRoll = (Math.random() * 50) + (movement.fervor/2);
+        if(cellRoll > 48){
+            nextState = spawnCellRandomLeader(nextState, movement.originLocation, 'rebel');
+        }
+    }
 
      for(const target of movementTargets){
          const targetIdeology = determinePotentialIdeology(nextState);

--- a/src/engine/politics/politics.ts
+++ b/src/engine/politics/politics.ts
@@ -2,6 +2,7 @@ import type { GameState, EngineResult, GameEvent } from '../../types/gameState';
 import { averagePopHappiness, findMigrationTarget, migratePop } from '../population';
 import { determinePotentialIdeology, spawnMovement } from './movements';
 import { spawnCellRandomLeader } from './cells';
+import { CASSIGNMENT_CATALOG } from '../../data/cellActivities';
 
 export function processPolitics(currentState: GameState ): EngineResult {
     const planetoids = Object.values(currentState.planetoids.entities);
@@ -59,6 +60,36 @@ export function processPolitics(currentState: GameState ): EngineResult {
          let spawnResults = spawnMovement(nextState, target, targetIdeology);
          nextState = spawnResults.newState;
          allPoliticsEvents.push(spawnResults.event);
+    }
+
+
+    //3 - evaluate Cell assignments
+    let incrementDuration: number[] = [];
+    const cells = Object.values(currentState.cells.entities);
+
+    for(const cell of cells){
+        if(cell.assignment.type === 'idle'){
+            //new assignment
+        }
+        else if(cell.assignment.progress === CASSIGNMENT_CATALOG[cell.assignment.type].duration){
+            //complete assignment
+        }
+        else{
+            //progress assignment
+            incrementDuration = [ ...incrementDuration, cell.id];
+        }
+    }
+
+    //4 - increment durations
+    let newCells = { ...nextState.cells.entities };
+    for(const cellId of incrementDuration){
+        newCells[cellId] = {
+            ...newCells[cellId],
+            assignment: {
+                ...newCells[cellId].assignment,
+                progress: newCells[cellId].assignment.progress + 1
+            }
+        };
     }
 
 

--- a/src/types/govState.ts
+++ b/src/types/govState.ts
@@ -64,7 +64,7 @@ export interface Org {
 export type Ideology = 'monarchist' | 'authoritarian' | 'republican' | 'corporate';
 
 export type CellType = 'rebel' | 'criminal' | 'corporate';
-export type CellAssignmentType = 'idle' | 'sabotage';
+export type CellAssignmentType = 'idle' | 'assassinateGovernor' | 'gatherStrength';
 
 export interface Cell {
     readonly id: number;

--- a/src/types/govState.ts
+++ b/src/types/govState.ts
@@ -78,6 +78,7 @@ export interface Cell {
 
     assignment: {
         type: CellAssignmentType;
+        target: number; //the id of a Planetoid or Cell targeted by the assignment
         progress: number;
     }
 }


### PR DESCRIPTION
Created logic to create Cells and have them conduct Assignments. This presently functions for 'rebel'-type Cells. Closes #58 