### PR TITLE
feat(state): Planetoids now have individually assigned PoliticalStatus

### DIFF
--- a/src/components/cards/PlanetStatus.tsx
+++ b/src/components/cards/PlanetStatus.tsx
@@ -1,6 +1,10 @@
 import { useGameStore } from '../../state/gameStore';
+import { useUiStore } from '../../state/uiStore';
+
+import Button from '../pure/Button';
 
 function PlanetStatus({ planetoidId }: { planetoidId: number }) {
+     const openAssignModal = useUiStore(state => state.openAssignModal);
 
     const getPlanetoidById = useGameStore(state => state.getPlanetoidById);
 
@@ -15,6 +19,7 @@ function PlanetStatus({ planetoidId }: { planetoidId: number }) {
         <div>
             <p>{planetoid.name}</p>
             <p>{planetoid.government.status}</p>
+             <Button onClick={() => openAssignModal("assign_status", { targetId: planetoid.id, position: "scientist"})}>Change Status</Button>
             <p>Population: {planetoid.population.total} </p>
         </div>
     );

--- a/src/components/cards/PlanetStatus.tsx
+++ b/src/components/cards/PlanetStatus.tsx
@@ -13,9 +13,9 @@ function PlanetStatus({ planetoidId }: { planetoidId: number }) {
 
     return(
         <div>
-        <p>{planetoid.name}</p>
-        <p>{planetoid.government.status}</p>
-        <p>Population: {planetoid.population.total} </p>
+            <p>{planetoid.name}</p>
+            <p>{planetoid.government.status}</p>
+            <p>Population: {planetoid.population.total} </p>
         </div>
     );
 }

--- a/src/components/cards/PlanetStatus.tsx
+++ b/src/components/cards/PlanetStatus.tsx
@@ -1,0 +1,23 @@
+import { useGameStore } from '../../state/gameStore';
+
+function PlanetStatus({ planetoidId }: { planetoidId: number }) {
+
+    const getPlanetoidById = useGameStore(state => state.getPlanetoidById);
+
+    const planetoid = getPlanetoidById(planetoidId);
+
+    if(!planetoid || !planetoid.government || !planetoid.population ){
+        return null;
+    }
+
+
+    return(
+        <div>
+        <p>{planetoid.name}</p>
+        <p>{planetoid.government.status}</p>
+        <p>Population: {planetoid.population.total} </p>
+        </div>
+    );
+}
+
+export default PlanetStatus;

--- a/src/components/modals/ModalManager.tsx
+++ b/src/components/modals/ModalManager.tsx
@@ -16,6 +16,7 @@ import DiplomacyPanel from '../panels/DiplomacyPanel';
 import PoliticsPanel from '../panels/PoliticsPanel';
 import ResearchPanel from '../panels/ResearchPanel';
 import HabitatAssignModal from './assignment_modals/HabitatAssignModal';
+import StatusAssignModal from './assignment_modals/StatusAssignModal';
 
 export function ModalManager() {
 	const activeModal = useUiStore(state => state.activeModal);
@@ -54,6 +55,8 @@ export function ModalManager() {
 			assignModal = <AnchorAssignModal/>; break;
 		case 'assign_habitat':
 			assignModal = <HabitatAssignModal/>; break;
+		case 'assign_status':
+			assignModal = <StatusAssignModal/>; break;
 	}
 
 	let panel = null;

--- a/src/components/modals/assignment_modals/StatusAssignModal.tsx
+++ b/src/components/modals/assignment_modals/StatusAssignModal.tsx
@@ -1,0 +1,49 @@
+import { useUiStore } from '../../../state/uiStore';
+import { useGameStore } from '../../../state/gameStore';
+import { useState } from 'react';
+
+import styles from './AssignModal.module.css';
+
+import { Button } from '../../pure/Button';
+
+import type { PoliticalStatus } from '../../../types/govState';
+
+
+function StatusAssignModal() {
+     const characterAssignTarget = useUiStore(state => state.characterAssignTarget); //which should be called simply assignTarget
+     const closeAssignModal = useUiStore(state => state.closeAssignModal);
+
+
+     const getPlanetoidById = useGameStore(state => state.getPlanetoidById);
+     const assignStatus = useGameStore(state => state.assignStatus);
+
+     const [selectedStatus, setSelectedStatus] = useState<PoliticalStatus | null>(null);
+
+     if(!characterAssignTarget){
+         return null;
+     }
+
+     const targetPlanetoid = getPlanetoidById(characterAssignTarget.targetId);
+
+     if(!targetPlanetoid){
+         return null;
+    }
+
+    return(
+        <div className={styles.assignModal}>
+            <h3>Assigning Political Status to {targetPlanetoid.name}</h3>
+
+            <Button key={"Core"} className={`${styles.characterButton} ${"Core" === selectedStatus ? styles.selected : ''}`} onClick={() => setSelectedStatus("Core")}>Core</Button>
+            <Button key={"Martial"} className={`${styles.characterButton} ${"Martial" === selectedStatus ? styles.selected : ''}`} onClick={() => setSelectedStatus("Martial")}>Core</Button>
+            <Button key={"Colony"} className={`${styles.characterButton} ${"Colony" === selectedStatus ? styles.selected : ''}`} onClick={() => setSelectedStatus("Colony")}>Core</Button>
+
+            <Button  disabled={!selectedStatus} className={styles.characterButton} onClick={() => {if(selectedStatus){
+                assignStatus({planetoidId: targetPlanetoid.id, newStatus: selectedStatus});
+                closeAssignModal();}}}>Assign </Button>
+
+            <Button className={styles.characterButton} onClick={closeAssignModal}>Close</Button>
+        </div>
+    );
+}
+
+export default StatusAssignModal;

--- a/src/components/modals/assignment_modals/StatusAssignModal.tsx
+++ b/src/components/modals/assignment_modals/StatusAssignModal.tsx
@@ -34,8 +34,8 @@ function StatusAssignModal() {
             <h3>Assigning Political Status to {targetPlanetoid.name}</h3>
 
             <Button key={"Core"} className={`${styles.characterButton} ${"Core" === selectedStatus ? styles.selected : ''}`} onClick={() => setSelectedStatus("Core")}>Core</Button>
-            <Button key={"Martial"} className={`${styles.characterButton} ${"Martial" === selectedStatus ? styles.selected : ''}`} onClick={() => setSelectedStatus("Martial")}>Core</Button>
-            <Button key={"Colony"} className={`${styles.characterButton} ${"Colony" === selectedStatus ? styles.selected : ''}`} onClick={() => setSelectedStatus("Colony")}>Core</Button>
+            <Button key={"Martial"} className={`${styles.characterButton} ${"Martial" === selectedStatus ? styles.selected : ''}`} onClick={() => setSelectedStatus("Martial")}>Martial</Button>
+            <Button key={"Colony"} className={`${styles.characterButton} ${"Colony" === selectedStatus ? styles.selected : ''}`} onClick={() => setSelectedStatus("Colony")}>Colony</Button>
 
             <Button  disabled={!selectedStatus} className={styles.characterButton} onClick={() => {if(selectedStatus){
                 assignStatus({planetoidId: targetPlanetoid.id, newStatus: selectedStatus});

--- a/src/components/panels/PoliticsPanel.tsx
+++ b/src/components/panels/PoliticsPanel.tsx
@@ -2,6 +2,8 @@ import { useUiStore } from '../../state/uiStore';
 import { useGameStore } from '../../state/gameStore';
 import styles from './Panel.module.css';
 
+import PlanetStatus  from '../cards/PlanetStatus';
+
 import { Button } from '../pure/Button';
 
 function PoliticsPanel() {
@@ -20,7 +22,8 @@ function PoliticsPanel() {
       return null;
     }
 
-
+    const planetoids = useGameStore(state => state.planetoids.entities);
+    const orgPlanetoids = Object.values(planetoids).filter(planetoid => planetoid.ownerNationId === 1);
 
     let leaderChar;
     if(playerOrg.characters.leaderId){
@@ -38,6 +41,19 @@ function PoliticsPanel() {
         <h3>Leader:</h3>
         {leaderChar ? <p>`{leaderChar.name.firstName} {leaderChar.name.lastName}`</p> : <p>Vacant</p>}
         {isAssignable && <Button onClick={() => openAssignModal("assign_character", {targetId: 1, position: 'leader'})}>Assign new Leader</Button>}
+
+
+        <h3>Planets</h3>
+        <ul>
+        {orgPlanetoids.map(planetoid => {
+          return(
+            <li key={planetoid.id}>
+            <PlanetStatus planetoidId={planetoid.id}/>
+            </li>
+          );
+        })}
+        </ul>
+
       </div>
     );
 

--- a/src/components/panels/PoliticsPanel.tsx
+++ b/src/components/panels/PoliticsPanel.tsx
@@ -36,7 +36,7 @@ function PoliticsPanel() {
 
 
         <h3>Leader:</h3>
-        {leaderChar ? <p>`${leaderChar.name.firstName} ${leaderChar.name.lastName}`</p> : <p>Vacant</p>}
+        {leaderChar ? <p>`{leaderChar.name.firstName} {leaderChar.name.lastName}`</p> : <p>Vacant</p>}
         {isAssignable && <Button onClick={() => openAssignModal("assign_character", {targetId: 1, position: 'leader'})}>Assign new Leader</Button>}
       </div>
     );

--- a/src/engine/colonization.ts
+++ b/src/engine/colonization.ts
@@ -68,9 +68,12 @@ export function colonizePlanetoid(currentState: GameState, payload: ColonizePayl
         politics: {}
       };
 
-      const updatedPlanetoid = {
+      const updatedPlanetoid: Planetoid = {
         ...planetoid,
         ownerNationId: ship.ownerNationId,
+        government: {
+          status: 'Colony',
+        },
         population: {
           total: 1,
           progress: 0,

--- a/src/engine/politics/politics.ts
+++ b/src/engine/politics/politics.ts
@@ -6,7 +6,34 @@ import { CASSIGNMENT_CATALOG } from '../../data/cellActivities';
 import type { Character } from '../../types/charState';
 import { generateCharacter, engineUnassignCharacter } from '../character';
 import { SUCCESSION_CATALOG } from '../../data/politics/succession';
+import type { PoliticalStatus } from '../../types/govState';
 
+
+export function engineAssignStatus(currentState: GameState, planetoidId: number, newStatus: PoliticalStatus){
+    let planetoid = currentState.planetoids.entities[planetoidId];
+    if(!planetoid){
+        return currentState;
+    }
+
+    //TODO: if planetoid.government does not exist, set it up. (also, spread it below)
+    planetoid = {
+        ...planetoid,
+        government: {
+            status: newStatus
+        }
+    };
+
+    return {
+        ...currentState,
+        planetoids: {
+            ...currentState.planetoids,
+            entities: {
+                ...currentState.planetoids.entities,
+                [planetoidId]: planetoid
+            }
+        }
+    };
+}
 
 
 export function governmentSuccession(currentState: GameState, orgId: number): GameState {

--- a/src/state/gameStore.ts
+++ b/src/state/gameStore.ts
@@ -368,6 +368,10 @@ export const useGameStore = create<GameStoreState>((set, get) => {
             popIds: localPops,
           };
 
+          home.government = {
+            status: 'Core'
+          };
+
           let homeBuildings: number[] = [];
 
           let startingFactory: Building = {

--- a/src/state/gameStore.ts
+++ b/src/state/gameStore.ts
@@ -26,8 +26,9 @@ import { normalize } from '../utils/normalize';
 //constant imports
 import { CYCLE_CONFIG } from '../constants/cycle_config';
 import { DEFAULT_GOODS} from '../data/goods';
-import { processPolitics } from '../engine/politics/politics';
+import { engineAssignStatus, processPolitics } from '../engine/politics/politics';
 import { processMilShips } from '../engine/ships/ships';
+import type { PoliticalStatus } from '../types/govState';
 
 
 export const useGameStore = create<GameStoreState>((set, get) => {
@@ -294,6 +295,10 @@ export const useGameStore = create<GameStoreState>((set, get) => {
 
   assignResearch: (payload: {buildingId: number, researchId: string }) => {
     set(engineAssignResearch(get(), payload.buildingId, payload.researchId));
+  },
+
+  assignStatus: (payload: {planetoidId: number, newStatus: PoliticalStatus }) => {
+    set(engineAssignStatus(get(),payload.planetoidId, payload.newStatus));
   },
 
   initializeNewGame: (payload: { playerOrgName: string, playerOrgColor: string, playerSpecies: string }) => {

--- a/src/types/gameState.ts
+++ b/src/types/gameState.ts
@@ -2,7 +2,7 @@ import type { Fleet, Ship, MilShip, ShipType, MilShipType } from './shipTypes';
 import type { Lane, System, Planetoid, PlanetoidClassification } from './geoState';
 import type { Resources, Good, GoodCategory } from './ecoState';
 import type { SkillName, Character, CharacterAssignment } from './charState';
-import type { Org, Cell, Movement } from './govState';
+import type { Org, Cell, Movement, PoliticalStatus } from './govState';
 
 export interface Process {
   input?: Partial<Resources>;
@@ -216,6 +216,7 @@ export interface GameActions {
   initializeNewGame: (payload: {playerOrgName: string, playerOrgColor: string, playerSpecies: string} ) => void;
   assignCharacter: (payload: {charId: number, assignmentTargetId: number, assignmentType: CharacterAssignment}) => void;
   assignResearch: (payload: {buildingId: number, researchId: string }) => void;
+  assignStatus: (payload: {planetoidId: number, newStatus: PoliticalStatus}) => void;
   getOrgResearchOptions: (orgId: number) => string[];
 }
 

--- a/src/types/geoState.ts
+++ b/src/types/geoState.ts
@@ -1,5 +1,7 @@
 //state for locations
 
+import type { PoliticalStatus } from "./govState";
+
 export interface System {
   readonly id: number;
   name: string;
@@ -25,6 +27,9 @@ export interface Planetoid {
   buildings: number[];
   structures: {
       habitats: number;
+  }
+  government?: {
+    status: PoliticalStatus;
   }
   ownerNationId: number | null;
   population?: {

--- a/src/types/govState.ts
+++ b/src/types/govState.ts
@@ -94,3 +94,6 @@ export interface Movement {
 
     fervor: number; //a number from 0-10
 }
+
+
+export type PoliticalStatus = 'Core' | 'Colony' | 'Occupied' | 'Anarchy' | 'Martial';

--- a/src/types/uiState.ts
+++ b/src/types/uiState.ts
@@ -3,7 +3,7 @@ import type { CharacterAssignment } from './charState';
 
 export type ModalType = "fleet_modal" | "system_modal" | "org_modal" | "ship_modal" | "planet_modal" | "building_modal" | "pops_modal";
 
-export type AssignType = "assign_character" | "assign_research" | "send_trade" | "assign_anchor" | "assign_habitat";
+export type AssignType = "assign_character" | "assign_research" | "send_trade" | "assign_anchor" | "assign_habitat" | "assign_status";
 
 export type PanelType = "diplomacy_panel" | "politics_panel" | "research_panel";
 


### PR DESCRIPTION
PoliticalStatus is intended to define the rights allowed to the Population of the Planetoid. It is changed via the PoliticsPanel, where Planetoids are now displayed using a new Card. This Card also has a button activating an AssignStatus Modal, where the user can modify the status of each owned Planetoid. Closes #127 