### PR TITLE
feat(engine): leader term lengths are now enforced

### DIFF
--- a/src/engine/galaxyGeneration.ts
+++ b/src/engine/galaxyGeneration.ts
@@ -521,7 +521,7 @@ export function generateStartingOrgs(numOrgs: number): {orgs: Org[], chars: Char
 			},
 			government: {
 				succession: "heriditary",
-				leaderTermDuration: 0,
+				leaderTermDuration: -1,
 				presentTermEnd: 0,
 				homeSystem: 0, //temp, to be overwritten during the findHomes phase of gameInit
 			},
@@ -570,8 +570,8 @@ export function generateStartingOrgs(numOrgs: number): {orgs: Org[], chars: Char
 			},
 			government: {
 				succession: "council",
-				leaderTermDuration: 0,
-				presentTermEnd: 0,
+				leaderTermDuration: 100,
+				presentTermEnd: 100,
 				homeSystem: 0, //temp, to be overwritten during the findHomes phase of gameInit
 			},
 			resources: { credits: 0, rocks: 0,  gas: 0 },

--- a/src/engine/politics/politics.ts
+++ b/src/engine/politics/politics.ts
@@ -72,6 +72,10 @@ export function governmentSuccession(currentState: GameState, orgId: number): Ga
         characters: {
             ...functionOrg.characters,
             leaderId: nextLeader.id
+        },
+        government: {
+            ...functionOrg.government,
+            presentTermEnd: currentState.meta.turn + functionOrg.government.leaderTermDuration
         }
     };
 

--- a/src/engine/politics/politics.ts
+++ b/src/engine/politics/politics.ts
@@ -93,8 +93,6 @@ export function governmentSuccession(currentState: GameState, orgId: number): Ga
         }
     }
 
-
-
     return nextState;
 }
 
@@ -104,6 +102,7 @@ export function governmentSuccession(currentState: GameState, orgId: number): Ga
 export function processPolitics(currentState: GameState ): EngineResult {
     const planetoids = Object.values(currentState.planetoids.entities);
     const allPoliticsEvents: GameEvent[] = [];
+    const orgs = Object.values(currentState.orgs.entities);
 
      let nextState = { ...currentState };
 
@@ -198,6 +197,20 @@ export function processPolitics(currentState: GameState ): EngineResult {
             entities: newCells
         }
     };
+
+
+
+    //4 - evaluate leader terms
+    for(const org of orgs){
+        if(org.government.leaderTermDuration === -1){
+            continue;
+        }
+
+        if(org.government.presentTermEnd <= currentState.meta.turn){
+            nextState = governmentSuccession(nextState, org.id);
+        }
+    }
+
 
     return { newState: nextState, events: allPoliticsEvents };
 }

--- a/src/types/govState.ts
+++ b/src/types/govState.ts
@@ -26,8 +26,8 @@ export interface Org {
     }
     government: {
         succession: string;
-        leaderTermDuration: number;
-        presentTermEnd: number;
+        leaderTermDuration: number; //semi-fixed number. -1 indicates no term duration
+        presentTermEnd: number; //calculated value of currentTick + leaderTermDuration
         homeSystem: number; //a System.id
     }
 


### PR DESCRIPTION
Upon expiration of leader term, governmentSuccession is called by processPolitics. This rotates the leader Character and sets the new term length. Closes #107 